### PR TITLE
Changed the line that checks for the SNS topic name.   I set up my LW…

### DIFF
--- a/lw_aws_preflight.sh
+++ b/lw_aws_preflight.sh
@@ -40,7 +40,7 @@ function get_trail_settings () {
   #echo $json
   export TRAIL=$(echo $json | jq -r '.Trail | .Name')
   export BUCKET=$(echo $json | jq -r '.Trail | .S3BucketName')
-  export SNSTOPIC=$(echo $json | jq -r '.Trail | index ("SnsTopicCT_ARN")')
+  export SNSTOPIC=$(echo $json | jq -r '.Trail | .SnsTopicName')
 }
 
 function check_encryption () {


### PR DESCRIPTION
Ran this script after configuring my LW Account with the CloudFormations script.   The preflight script continued to error our saying the SNS topic was not configured. I modified the SNSTOPIC env variable to capture that value a different way.    

script output before change: https://share.getcloudapp.com/7Kuplq5k