### PR TITLE
ALLY-474: fix - gcp: Modified script to get a cleaner resource count

### DIFF
--- a/lw_gcp_inventory.sh
+++ b/lw_gcp_inventory.sh
@@ -23,8 +23,11 @@ function isComputeEnabled {
   gcloud services list --format json | jq -r '.[] | .name' | grep -q "compute.googleapis.com"
 }
 
+# NOTE - it is technically possible to have a CloudSQL instance without the 
+# sqladmin API enabled; but you cannot check the instance programatically 
+# without the API enabled
 function isCloudSQLEnabled {
-  gcloud services list --format json | jq -r '.[] | .name' | grep -q "sql-component.googleapis.com" 
+  gcloud services list --format json | jq -r '.[] | .name' | grep -q "sqladmin.googleapis.com" 
 }
 
 function getGKEInstances {
@@ -40,11 +43,11 @@ function getSQLInstances {
 }
 
 function getLoadBalancers {
-  gcloud compute url-maps list --format json | jq length
+  gcloud compute forwarding-rules list --format json | jq length
 }
 
 function getGateways {
-  gcloud compute networks list --format json | jq '[.[] | .subnetworks | length] | add'
+  gcloud compute routers list --format json | jq '[.[] | .nats | length] | add'
 }
 
 # Define PROJECT_IDS above to scan a subset of projects. Otherwise we scan


### PR DESCRIPTION
This PR modifies the GCP inventory script in the following ways:

- Modifies the CloudSQL check to query for the `sqladmin` API vs. the `sql-component` API
  - While the `sql-component` API is required for CloudSQL, you can't query for it without the `sqladmin` API
- Modifies the Load Balancers check to look for `forwarding-rules` vs `url-maps`
  - `url-maps` only covers HTTP/S (L7) Load Balancers and wouldn't count TCP (L4) Load Balancers; `forwarding-rules` will show both styles
- Modifies the Gateways check to look for Cloud NAT deployments vs. counting VPC subnetworks