### PR TITLE
GCP Exploit Script

### DIFF
--- a/bash/lw_gcp_exploit.sh
+++ b/bash/lw_gcp_exploit.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Lacework sample GCP exploit
-# Creates a new user with power user privileges, then creates an S3 bucket and puts a file into it.
+# Creates a new service account user with editor privileges for the specified project_id, then creates a GCP storage bucket and puts a file into it.
 # The script then cleans up after itself, deleting the bucket and the user.
 # Accepts an optional argument for the username that gets created, otherwise defaults to 'system'
 set -e
@@ -54,7 +54,13 @@ IAM_ACCOUNT=$USERNAME@$PROJECT_ID.iam.gserviceaccount.com
 
 # Saving core.account
 CORE_ACCOUNT=$(gcloud config list account --format "value(core.account)" --format=json | jq -r .core.account)
-echo "${grn}Stashing core account ${mag}$CORE_ACCOUNT${end}"
+CORE_ACCOUNT_PROJECT_ID=$(gcloud config get-value project)
+echo "${grn}Stashing core account settings ${mag}$CORE_ACCOUNT${end}"
+echo ""
+
+# Setting Project
+gcloud config set project $PROJECT_ID
+echo "${grn}Setting core account project to ${mag}$PROJECT_ID${end}"
 echo ""
 
 # Create a new IAM user
@@ -94,8 +100,9 @@ gcloud iam service-accounts keys delete $KEY --iam-account=$IAM_ACCOUNT --quiet
 gcloud iam service-accounts delete $IAM_ACCOUNT --quiet
 echo ""
 
-echo "${grn}Reinitializing regular context with ${mag}$CORE_ACCOUNT${end}"
+echo "${grn}Reinitializing original context with ${mag}$CORE_ACCOUNT ${grn}${grn}${grn}${grn}${grn}${grn}${grn}${grn}${grn}with project_id ${mag}$CORE_ACCOUNT_PROJECT_ID${end}"
 gcloud config set account $CORE_ACCOUNT
+gcloud config set project $CORE_ACCOUNT_PROJECT_ID
 rm creds.json badfile.json
 
 echo ""

--- a/bash/lw_gcp_exploit.sh
+++ b/bash/lw_gcp_exploit.sh
@@ -1,0 +1,102 @@
+#!/bin/sh
+# Lacework sample GCP exploit
+# Creates a new user with power user privileges, then creates an S3 bucket and puts a file into it.
+# The script then cleans up after itself, deleting the bucket and the user.
+# Accepts an optional argument for the username that gets created, otherwise defaults to 'system'
+set -e
+
+red=$'\e[1;31m'
+grn=$'\e[1;32m'
+yel=$'\e[1;33m'
+blu=$'\e[1;34m'
+mag=$'\e[1;35m'
+cyn=$'\e[1;36m'
+end=$'\e[0m'
+
+usage="$(basename "$0") [-h] [-p <PROJECT_ID>] [-u <USERNAME>]
+
+This is a script to simulate a malicious execution event in a GCP environment.
+
+Arguments:
+    -h  show this help text
+    -p  set the project ID
+    -u  set the username (default: system)
+"
+
+USERNAME=system
+while getopts ':hp:u:' option; do
+  case "$option" in
+    h) echo "$usage"
+       exit
+       ;;
+    p) PROJECT_ID=${OPTARG}
+       ;;
+    u) USERNAME=${OPTARG}
+       ;;
+    :) printf "Missing argument for -%s\n" "$OPTARG" >&2
+       echo "$usage" >&2
+       exit 1
+       ;;
+   \?) printf "Illegal option: -%s\n" "$OPTARG" >&2
+       echo "$usage" >&2
+       exit 1
+       ;;
+  esac
+done
+shift $((OPTIND - 1))
+
+if [ -z "$PROJECT_ID" ]; then
+    echo "Missing project ID option. Use -h for help message."
+    exit 1
+fi
+
+IAM_ACCOUNT=$USERNAME@$PROJECT_ID.iam.gserviceaccount.com
+
+# Saving core.account
+CORE_ACCOUNT=$(gcloud config list account --format "value(core.account)" --format=json | jq -r .core.account)
+echo "${grn}Stashing core account ${mag}$CORE_ACCOUNT${end}"
+echo ""
+
+# Create a new IAM user
+echo "${grn}Creating a new IAM user called ${mag}$USERNAME${end}"
+echo ""
+gcloud iam service-accounts create $USERNAME --format=json | jq
+gcloud iam service-accounts keys create creds.json --iam-account=$IAM_ACCOUNT --format=json | jq
+echo ""
+echo "${grn}Granting Editor access to ${mag}$USERNAME${end}"
+gcloud projects add-iam-policy-binding $PROJECT_ID --member="serviceAccount:$IAM_ACCOUNT" --role=roles/editor --format=json | jq
+echo ""
+echo ""
+gcloud auth activate-service-account --key-file=creds.json
+
+KEY=$(cat creds.json | jq -r .private_key_id)
+
+# Here we start using the new account profile and creds
+echo ""
+echo "${grn}Creating a new GCP Storage bucket and uploading a file...${end}"
+BUCKET=lacework-test-$RANDOM
+gsutil mb -p $PROJECT_ID -l US-EAST1 gs://$BUCKET
+curl -s -H "Accept: application/json" https://icanhazdadjoke.com/ > badfile.json
+echo ""
+echo "${grn}Uploading secret data...${end}"
+gsutil cp badfile.json gs://$BUCKET/
+echo ""
+echo "${grn}Data uploaded. Preparing to destroy...${end}"
+sleep 5
+echo ""
+echo "${grn}Deleting file and GCP Storage bucket...${end}"
+gsutil rm -r gs://$BUCKET
+echo ""
+
+# Exit back out to our regular context
+echo "${grn}Cleaning up...${end}"
+gcloud iam service-accounts keys delete $KEY --iam-account=$IAM_ACCOUNT --quiet
+gcloud iam service-accounts delete $IAM_ACCOUNT --quiet
+echo ""
+
+echo "${grn}Reinitializing regular context with ${mag}$CORE_ACCOUNT${end}"
+gcloud config set account $CORE_ACCOUNT
+rm creds.json badfile.json
+
+echo ""
+echo "${cyn}Script complete. Check your Lacework console for activity in about an hour.${end}"


### PR DESCRIPTION
Added a script to simulate the usage of "compromised creds" to create a new service account with editor privileges in a specified GCP project, then creates a storage bucket and put a file into it before deleting it.

The result is a GCP Audit Trail polygraph event based on the new user and subsequent activity.

This script is a mirror of the lw_aws_exploit.sh script activity for GCP.

Usage:
`./lw_gcp_exploit.sh -p <PROJECT_ID> -u <USERNAME>`

Example:
`./lw_gcp_exploit.sh -p lw-bank-of-anthos -u sketchy-user`

Help Message:
`./lw_gcp_exploit.sh -h`

Example Polygraph Activity:
![image](https://user-images.githubusercontent.com/63012288/141511849-001d3ba4-e3ab-4ca2-b882-b53172bd79f1.png)

Example Event:
![image](https://user-images.githubusercontent.com/63012288/141511883-24f37b8e-2bf0-4d17-b4cf-860f39c7da78.png)


