### PR TITLE
Adding AWS SSM doc to install datacollectors

### DIFF
--- a/AWS-System-Manager/README.md
+++ b/AWS-System-Manager/README.md
@@ -1,0 +1,12 @@
+### AWS System Manager Document for Lacework Agent Installation ###
+
+This is the AWS Systems Manager document created by the [Lacework Terraform module to install agents on EC2 instances](https://docs.lacework.com/install-agent-on-aws-ec2-instances-using-terraform-and-aws-systems-manager).  Useful for 
+shops that don't/can't/won't use Terraform.
+
+To use the SSM doc:
+ - Replace `default: <YOUR TOKEN>` with your [AWS Agent Access Token](https://docs.lacework.com/create-agent-access-tokens-and-download-agent-installers)
+ - Create an [AWS SSM Document](https://docs.aws.amazon.com/systems-manager/latest/userguide/create-ssm-doc.html).
+ - If desired, restrict the installation scope using tags, etc.  
+ - Publish the AWS SSM document
+ - ???
+ - Profit!

--- a/AWS-System-Manager/aws-ssm-install-datacollector.yml
+++ b/AWS-System-Manager/aws-ssm-install-datacollector.yml
@@ -1,0 +1,64 @@
+---
+description: Setup the Lacework agent on a Linux instance
+mainSteps:
+- action: aws:runShellScript
+  inputs:
+    runCommand:
+    - |
+      #!/usr/bin/env bash
+      set -e
+      LACEWORK_INSTALL_PATH="{{ LaceworkInstallPath }}"
+      # TODO: Fetch the token from AWS SSM Parameter Store instead of taking it in as a Command parameter (avoid leaks in the AWS Console)
+      TOKEN='{{ Token }}'
+      TAGS='{{ Tags }}'
+      # TODO: Handle systems that don't have systemctl
+      if systemctl list-unit-files | grep kube; then
+        echo "This host appears to be a Kubernetes node, please use the Kubernetes deployment method (https://support.lacework.com/hc/en-us/articles/360005263034-Deploy-on-Kubernetes)."
+        exit 0
+      fi
+      if [ ! -d "$LACEWORK_INSTALL_PATH" ]; then
+        echo "Lacework agent not installed, installing..."
+        # TODO: Add the support for hosts that don't have curl installed
+        # TODO: Verify the signature of the install.sh script
+        curl https://packages.lacework.net/install.sh >/tmp/install.sh
+        chmod +x /tmp/install.sh
+        # TODO: Pass tags to the installation script
+        sudo /tmp/install.sh "$TOKEN"
+        rm /tmp/install.sh
+      fi
+      # TODO: Add the support for other Lacework configuration options
+      echo "Updating the Lacework agent config.json file..."
+      cat >"$LACEWORK_INSTALL_PATH/config/config.json" <<EOF
+      {
+        "tokens": {
+          "AccessToken": "$TOKEN"
+        },
+        "tags": $TAGS
+      }
+      EOF
+      # Make sure the Lacework datacollector service is enabled and running
+      if ! systemctl is-active --quiet datacollector; then
+        echo "Enabling the Lacework datacollector service"
+        systemctl enable datacollector
+        systemctl start datacollector
+      fi
+      echo "Lacework configured successfully!"
+  name: SetupLaceworkAgent
+  precondition:
+    StringEquals:
+    - platformType
+    - Linux
+parameters:
+  LaceworkInstallPath:
+    default: "/var/lib/lacework"
+    description: The expected Lacework installation path
+    type: String
+  Tags:
+    default: '{"env":"testing"}'
+    description: The Lacework agent token
+    type: String
+  Token:
+    default: <YOUR TOKEN>
+    description: The access token for the Lacework agent
+    type: String
+schemaVersion: '2.2'


### PR DESCRIPTION
Originally created by @ipcrm in a [Gist](https://gist.github.com/ipcrm/f7833ae1ab67996cd422fef7ebc43388).  Using AWS SSM directly has been the second most popular and simple method for installing LW data collectors after just Terraform.  This is the document created by our TF, so shops that don't use TF for whatever reason will find this very useful.  