### PR TITLE
Add a default region for `ec2 describe-regions`

### DIFF
--- a/bash/lw_aws_inventory.sh
+++ b/bash/lw_aws_inventory.sh
@@ -45,7 +45,7 @@ LAMBDA_FNS=0
 LAMBDA_FNS_EXIST="No"
 
 function getRegions {
-  aws --profile $profile ec2 describe-regions --output json | jq -r '.[] | .[] | .RegionName'
+  aws --profile $profile --region us-east-1 ec2 describe-regions --output json | jq -r '.[] | .[] | .RegionName'
 }
 
 function getInstances {


### PR DESCRIPTION
In our case, we do not use the `default` AWS profile (so as to avoid using the wrong one). *Even when specifying a profile with a region set in the config*, the `ec2 describe-regions` command stumbles, with the error: `You must specify a region. You can also configure your region by running "aws configure"`. In this case, _any region_ can be used for this command, and it _correctly_ returns all the regions regardless of which region is specified. This change hard-codes a default.