### PR TITLE
Only count the running and stopped instances

### DIFF
--- a/bash/lw_aws_inventory.sh
+++ b/bash/lw_aws_inventory.sh
@@ -49,7 +49,7 @@ function getRegions {
 }
 
 function getInstances {
-  aws --profile $profile ec2 describe-instances --query 'Reservations[*].Instances[*].[InstanceId]' --region $r --output json --no-paginate | jq 'flatten | length'
+  aws --profile $profile ec2 describe-instances --query 'Reservations[*].Instances[*].[InstanceId]' --filters Name=instance-state-name,Values=running,stopped --region $r --output json --no-paginate | jq 'flatten | length'
 }
 
 function getRDSInstances {


### PR DESCRIPTION
The script currently counts the terminated EC2 instances, this skews the license count.
I have added a filter to only count the running and stopped instances.