### PR TITLE
Increased AWS retry-limit

### DIFF
--- a/bash/lw_aws_inventory.sh
+++ b/bash/lw_aws_inventory.sh
@@ -10,6 +10,7 @@
 
 
 AWS_PROFILE=default
+AWS_MAX_ATTEMPTS=20
 
 # Usage: ./lw_aws_inventory.sh
 while getopts ":jp:" opt; do


### PR DESCRIPTION
Increased AWS_MAX_ATTEMPTS from default 2 to 20 to work around API throttling by the AWS API.