### PR TITLE
Revert "Increased AWS retry-limit"

### DIFF
--- a/bash/lw_aws_inventory.sh
+++ b/bash/lw_aws_inventory.sh
@@ -10,7 +10,6 @@
 
 
 AWS_PROFILE=default
-AWS_MAX_ATTEMPTS=20
 
 # Usage: ./lw_aws_inventory.sh
 while getopts ":jp:" opt; do


### PR DESCRIPTION
Reverts lacework-dev/scripts#47

Need to add `export` before `AWS_MAX_ATTEMPTS=20` to set the environment variable