### PR TITLE
Script clean up

### DIFF
--- a/bash/lw_azure_inventory.sh
+++ b/bash/lw_azure_inventory.sh
@@ -12,7 +12,7 @@ LOAD_BALANCERS=0
 GATEWAYS=0
 
 function getSubscriptions {
-  az account list | jq -r '.[] | .id'
+  az account list --query "[?name != 'Access to Azure Active Directory']" | jq -r '.[] | .id'
 }
 
 function setSubscription {
@@ -43,10 +43,6 @@ function getLoadBalancers {
 function getGateways {
   RG=$1
   az network vnet-gateway list --resource-group $RG | jq length
-}
-
-function getSubscriptions {
-  az account list | jq -r '.[] | .id'
 }
 
 originalsub=$(az account show | jq -r '.id')


### PR DESCRIPTION
* Removed duplicate getSubscriptions function.
* Removed legacy subscription "Access to Azure Active Directory" which leads to errors (see https://www.jasonfritts.me/2020/04/07/what-is-the-access-to-azure-active-directory-subscription-for/ for more information).