### PR TITLE
fix: disabling STS checks for assumed roles

### DIFF
--- a/bash/lw_aws_agentless_preflight.sh
+++ b/bash/lw_aws_agentless_preflight.sh
@@ -76,14 +76,6 @@ function checkStatusByRegion () {
   done
 }
 
-function echoStatus () {
-  if [ "${1}" == "ok" ]; then
-    echo "${OK}  ${2}"
-  elif [ "$1" == "warning" ]; then
-    echo "${WARN}  ${2}"
-  elif [ "$1" == "error" ]; then
-    echo "${NO}  ${2}"
-  fi
 }
 
 function getSessionToken () {

--- a/bash/lw_aws_agentless_preflight.sh
+++ b/bash/lw_aws_agentless_preflight.sh
@@ -76,6 +76,8 @@ function checkStatusByRegion () {
   done
 }
 
+function isAssumedRole() {
+  aws sts get-caller-identity | jq -r '.Arn | contains(":assumed-role/")'
 }
 
 function getSessionToken () {
@@ -127,6 +129,7 @@ else
 fi
 
 RESULT_REGIONS=""
+isAssumedRole=$(isAssumedRole)
 vpcQuotaStatuses="$(getVpcQuotaStatus)"
 vpcIntGatewayQuotaStatuses="$(getVpcIntGatewayQuotaStatus)"
 echo "Gathering enabled regions..."
@@ -137,8 +140,8 @@ for region in $(getEnabledRegions); do
   skip=false
 
   # Check that STS is enabled
-  if [[ -z $(getSessionToken $region) ]]; then
-    echo "${NO}  STS Service"
+  if [[ $isAssumedRole == false ]] && [[ -z $(getSessionToken $region) ]]; then
+    echo "${NO}  STS Service appears to be disabled, excluding region."
     skip=true
   fi
 


### PR DESCRIPTION
Disabling STS regional checks for assumed roles until I can figure out another way to do it.  `get-caller-identity` seems to always work even for a disabled region, so need to figure out another way.