### PR TITLE
chore: temporarily disabling STS checks

### DIFF
--- a/bash/lw_aws_agentless_preflight.sh
+++ b/bash/lw_aws_agentless_preflight.sh
@@ -140,10 +140,10 @@ for region in $(getEnabledRegions); do
   skip=false
 
   # Check that STS is enabled
-  if [[ $isAssumedRole == false ]] && [[ -z $(getSessionToken $region) ]]; then
-    echo "${NO}  STS Service appears to be disabled, excluding region."
-    skip=true
-  fi
+  # if [[ $isAssumedRole == false ]] && [[ -z $(getSessionToken $region) ]]; then
+  #   echo "${NO}  STS Service appears to be disabled, excluding region."
+  #   skip=true
+  # fi
 
   # Check VPC Quota
   status=$(checkStatusByRegion $region $vpcQuotaStatuses)


### PR DESCRIPTION
Disabling STS checks temporarily until I can figure out a more accurate way of checking.  Even though the STS status is available in `IAM -> Access Management -> Account settings` I haven't yet located an API that returns this data programatically.