### PR TITLE
Update lw_azure_inventory.sh

### DIFF
--- a/bash/lw_azure_inventory.sh
+++ b/bash/lw_azure_inventory.sh
@@ -11,10 +11,6 @@ SQL_SERVERS=0
 LOAD_BALANCERS=0
 GATEWAYS=0
 
-function getSubscriptions {
-  az account list | jq -r '.[] | .id'
-}
-
 function setSubscription {
   SUB=$1
   az account set --subscription $SUB
@@ -46,7 +42,7 @@ function getGateways {
 }
 
 function getSubscriptions {
-  az account list | jq -r '.[] | .id'
+  az account list --query "[?name != 'Access to Azure Active Directory']" | jq -r '.[] | .id'
 }
 
 originalsub=$(az account show | jq -r '.id')


### PR DESCRIPTION
Filter legacy Azure AD subscription from scope as it cannot be queried. 
> ERROR: (DisallowedOperation) The current subscription type is not permitted to perform operations on any provider namespace. Please use a different subscription.
Code: DisallowedOperation

Removed duplicate getSubscriptions function definition.