### PR TITLE
Update lw_gcp_inventory.sh

### DIFF
--- a/bash/lw_gcp_inventory.sh
+++ b/bash/lw_gcp_inventory.sh
@@ -31,7 +31,7 @@ function isCloudSQLEnabled {
 }
 
 function getGKEInstances {
-  gcloud compute instances list --format json | jq '[.[] | select(.name | contains("gke-"))] | length'
+  gcloud container clusters list --format json | jq '[.[].currentNodeCount] | add'
 }
 
 function getGCEInstances {
@@ -94,7 +94,7 @@ echo "######################################################################"
 echo "Lacework inventory collection complete."
 echo ""
 echo "GCE Instances:   $GCE_INSTANCES"
-echo "GKE Instances:   $GKE_INSTANCES"
+echo "GKE Nodes:   $GKE_INSTANCES"
 echo "Load Balancers:  $LOAD_BALANCERS"
 echo "Gateways:        $GATEWAYS"
 echo "SQL Instances:   $SQL_INSTANCES"


### PR DESCRIPTION
Changed output from "GKE Instances" to "GKE Nodes" as we are in reality counting the number of K8 nodes which we also use for licensing. 
Changed the way how we count GKE nodes as this wouldn't catch GKE Autopilot nodes which we will support shortly.