### PR TITLE
Fix: (RAIN-42946): Update preflight script to break up deploy managed permissions roles

### DIFF
--- a/bash/lw_aws_agentless_preflight.sh
+++ b/bash/lw_aws_agentless_preflight.sh
@@ -52,13 +52,6 @@ function hasStackSetExecutionRole () {
   aws iam list-roles | jq -r '.Roles[] | select(.RoleName == "AWSCloudFormationStackSetExecutionRole")'
 }
 
-function hasSelfManagedRoles() {
-  if [[ ! -z $(hasStackSetAdministrationRole) ]] && [[ ! -z $(hasStackSetExecutionRole) ]]
-  then
-    echo "Self Managed Roles Exist"
-  fi
-}
-
 function getEnabledRegions () {
   aws ec2 describe-regions --all-regions | jq -r '.Regions[] | select(.OptInStatus != "not-opted-in") | .RegionName'
 }
@@ -102,7 +95,8 @@ function printOutput () {
   echo "    Lacework Agentless Preflight Results"
   echo "--------------------------------------------"
   echo ""
-  echo "Deploy Self Managed Permissions? $RESULT_SELF_MANAGED_DEPLOY"
+  echo "Deploy Self Managed Permissions (Administration Role)? $RESULT_CLOUDFORMATION_STACK_SET_ADMINISTRATION_ROLE"
+  echo "Deploy Self Managed Permissions (Execution Role)? $RESULT_CLOUDFORMATION_STACK_SET_ADMINISTRATION_ROLE"
   echo "Deploy ECS Service Linked Role?  $RESULT_ECS_ROLE_DEPLOY"
   echo ""
   echo "Recommended Deployment Regions:"
@@ -110,13 +104,22 @@ function printOutput () {
   echo "********************************************"
 }
 
-result=$(hasSelfManagedRoles)
+result=$(hasStackSetAdministrationRole)
 if [[ ! -z $result ]]; then
-  echo "${OK}  Cloudformation StackSet 'Self-Managed' roles exist."
-  RESULT_SELF_MANAGED_DEPLOY="No"
+  echo "${OK}  Cloudformation StackSet Administration role exists."
+  RESULT_CLOUDFORMATION_STACK_SET_ADMINISTRATION_ROLE="No"
 else
-  echo "${WARN}  Cloudformation StackSet 'Self-Managed' roles do not exist."
-  RESULT_SELF_MANAGED_DEPLOY="Yes"
+  echo "${WARN}  Cloudformation StackSet Administration role does not exist."
+  RESULT_CLOUDFORMATION_STACK_SET_ADMINISTRATION_ROLE="Yes"
+fi
+
+result=$(hasStackSetExecutionRole)
+if [[ ! -z $result ]]; then
+  echo "${OK}  Cloudformation StackSet Execution role exists."
+  RESULT_CLOUDFORMATION_STACK_SET_ADMINISTRATION_ROLE="No"
+else
+  echo "${WARN}  Cloudformation StackSet Execution role does not exist."
+  RESULT_CLOUDFORMATION_STACK_SET_ADMINISTRATION_ROLE="Yes"
 fi
 
 result=$(hasEcsRole)

--- a/bash/lw_aws_agentless_preflight.sh
+++ b/bash/lw_aws_agentless_preflight.sh
@@ -95,8 +95,8 @@ function printOutput () {
   echo "    Lacework Agentless Preflight Results"
   echo "--------------------------------------------"
   echo ""
-  echo "Deploy Self Managed Permissions (Administration Role)? $RESULT_CLOUDFORMATION_STACK_SET_ADMINISTRATION_ROLE"
-  echo "Deploy Self Managed Permissions (Execution Role)? $RESULT_CLOUDFORMATION_STACK_SET_ADMINISTRATION_ROLE"
+  echo "Deploy CloudFormation StackSet Administration Role? $RESULT_CLOUDFORMATION_STACK_SET_ADMINISTRATION_ROLE"
+  echo "Deploy CloudFormation StackSet Execution Role? $RESULT_CLOUDFORMATION_STACK_SET_EXECUTION_ROLE"
   echo "Deploy ECS Service Linked Role?  $RESULT_ECS_ROLE_DEPLOY"
   echo ""
   echo "Recommended Deployment Regions:"
@@ -116,10 +116,10 @@ fi
 result=$(hasStackSetExecutionRole)
 if [[ ! -z $result ]]; then
   echo "${OK}  Cloudformation StackSet Execution role exists."
-  RESULT_CLOUDFORMATION_STACK_SET_ADMINISTRATION_ROLE="No"
+  RESULT_CLOUDFORMATION_STACK_SET_EXECUTION_ROLE="No"
 else
   echo "${WARN}  Cloudformation StackSet Execution role does not exist."
-  RESULT_CLOUDFORMATION_STACK_SET_ADMINISTRATION_ROLE="Yes"
+  RESULT_CLOUDFORMATION_STACK_SET_EXECUTION_ROLE="Yes"
 fi
 
 result=$(hasEcsRole)


### PR DESCRIPTION
Update agentless pre-flight script to break up deploy managed permissions roles into their respective roles. This goes along with the change here, to then reflect the same verbiage in this pre-flight script that we are updating to: https://github.com/lacework/rainbow/pull/10770

Jira ticket: https://lacework.atlassian.net/browse/RAIN-42946