### PR TITLE
[aws inventory] fix scanning all regions

### DIFF
--- a/bash/lw_aws_inventory.sh
+++ b/bash/lw_aws_inventory.sh
@@ -289,9 +289,8 @@ function calculateInventory {
   if [ -z "$regionsToScan" ]
   then
       # Regions to scan not set, get list from AWS
-      regionsToScan=$(getRegions)
+      regionsToScan=$(getRegions "$profile_string")
   fi
-
   for r in $regionsToScan; do
     if [[ $PRINT_CSV_DETAILS == "true" ]]
     then


### PR DESCRIPTION
`getRegions` function has no profile argument passed to it and fails as such:
```
$ ./lw_aws_inventory.sh -p Account123-RoleABC

"Profile", "Account ID", "Regions", "EC2 Instances", "EC2 vCPUs", "ECS Fargate Clusters", "ECS Fargate Running Containers/Tasks", "ECS Fargate CPU Units", "ECS Fargate License vCPUs", "Lambda Functions", "MB Lambda Memory", "Lambda License vCPUs", "Total vCPUSs"
Account123-RoleABC, 123456790,
You must specify a region. You can also configure your region by running "aws configure".
Regions: , 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
######################################################################
Lacework inventory collection complete.
```

After this change, it properly scans all regions:
```
$ ./lw_aws_inventory.sh -p Account123-RoleABC

"Profile", "Account ID", "Regions", "EC2 Instances", "EC2 vCPUs", "ECS Fargate Clusters", "ECS Fargate Running Containers/Tasks", "ECS Fargate CPU Units", "ECS Fargate License vCPUs", "Lambda Functions", "MB Lambda Memory", "Lambda License vCPUs", "Total vCPUSs"
Account123-RoleABC, 123456790, ap-south-1 eu-north-1 eu-west-3 eu-west-2 eu-west-1 ap-northeast-3 ap-northeast-2 ap-northeast-1 ca-central-1 sa-east-1 ap-southeast-1 ap-southeast-2 eu-central-1 us-east-1 us-east-2 us-west-1 us-west-2, <snip>
######################################################################
Lacework inventory collection complete.
```