### PR TITLE
Add script to only format OCI createAccount payload

### DIFF
--- a/lw-oci-integration/bash/README.md
+++ b/lw-oci-integration/bash/README.md
@@ -3,9 +3,9 @@
 ## Introduction
 
 * ```lacework_oci_integration_setup.sh```
-Tested against identity-domain tenancy. For classic (IDCS) based OCI tenancy, we recommend following the manual steps and the helper script lacework_integration_payload.sh..
+Tested against identity-domain tenancy. For classic (IDCS) based OCI tenancy, it may be necessary to fall back to the manual steps.
 Script uses the OCI CLI to create the OCI service account, OCI group and policy. It then uses the lacework CLI to create the integration to Lacework.
 Run script and provide values as prompted.
 
-* ```lacework_integration_payload.sh``` only produces the JSON payload that can then be used to create the integration to Lacework using endpoint /api/v2/CloudAccounts
+* ```lacework_integration_payload.sh``` only produces the JSON payload that can then be used to create the integration to Lacework using endpoint /api/v2/CloudAccounts. Intended to be used when a more manual or custom workflow is necessary.
 Please edit script before use to set the six variables appropriately. When executed, the script produces the payload in file ```lacework_payload.json```.

--- a/lw-oci-integration/bash/README.md
+++ b/lw-oci-integration/bash/README.md
@@ -1,0 +1,11 @@
+# scripts for integrating OCI to Lacework
+
+## Introduction
+
+* ```lacework_oci_integration_setup.sh```
+Tested against identity-domain tenancy. For classic (IDCS) based OCI tenancy, we recommend following the manual steps and the helper script lacework_integration_payload.sh..
+Script uses the OCI CLI to create the OCI service account, OCI group and policy. It then uses the lacework CLI to create the integration to Lacework.
+Run script and provide values as prompted.
+
+* ```lacework_integration_payload.sh``` only produces the JSON payload that can then be used to create the integration to Lacework using endpoint /api/v2/CloudAccounts
+Please edit script before use to set the six variables appropriately. When executed, the script produces the payload in file ```lacework_payload.json```.

--- a/lw-oci-integration/bash/lacework_integration_payload.sh
+++ b/lw-oci-integration/bash/lacework_integration_payload.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+if ! which jq > /dev/null; then
+    echo "this script requires jq - install jq to continue"
+    exit 1
+fi
+
+OUTPUT_FILE="lacework_payload.json"
+
+LACEWORK_OCI_USERNAME="ocid1.user.oc1..aaaaaaaaa3sq6j7icod2o6iky5smahcgt6xurxkuxzigyumpcg4rgyq5abcd"
+OCI_TENANCY_OCID="ocid1.tenancy.oc1..aaaaaaaatxph3zpu3jkem4cseejktwllb6dgsam7cx3jy63pazejzobvabcd"
+OCI_HOME_REGION="us-sanjose-1"
+OCI_TENANT_NAME="main tenant"
+
+LACEWORK_PRIVATE_KEY_PATH="/pathto/oci_api_key_lacework.pem"
+LACEWORK_PRIVATE_KEY_FINGERPRINT="1c:17:64:82:0d:86:c8:1d:8a:b6:d1:12:b7:a4:b2:cc"
+
+LACEWORK_INTEGRATION_NAME="oci-$OCI_TENANT_NAME"
+contents=$(cat $LACEWORK_PRIVATE_KEY_PATH)
+formatted_contents=$(echo "$contents" | awk '{ printf "%s\n", $0 }')
+jq -n \
+    --arg fc "$formatted_contents" \
+    --arg li "$LACEWORK_INTEGRATION_NAME" \
+    --arg ohc "$OCI_HOME_REGION" \
+    --arg oti "$OCI_TENANCY_OCID" \
+    --arg otn "$OCI_TENANT_NAME" \
+    --arg oui "$LACEWORK_OCI_USERNAME" \
+    --arg fp "$LACEWORK_PRIVATE_KEY_FINGERPRINT" \
+    '{"name": $li, "type": "OciCfg", "enabled": 1, "data": { "homeRegion": $ohc, "tenantId": $oti, "tenantName": $otn, "userOcid": $oui, "credentials": { "fingerprint": $fp, "privateKey": $fc }}}' > $OUTPUT_FILE

--- a/lw-oci-integration/bash/lacework_integration_payload.sh
+++ b/lw-oci-integration/bash/lacework_integration_payload.sh
@@ -9,12 +9,12 @@ OUTPUT_FILE="lacework_payload.json"
 
 # Values of 6 variables below should be changed before running script:
 
-LACEWORK_OCI_USERNAME="ocid1.user.oc1..aaaaaaaaa3sq6j7icod2o6iky5smahcgt6xurxkuxzigyumpcg4rgyq5abcd"
-OCI_TENANCY_OCID="ocid1.tenancy.oc1..aaaaaaaatxph3zpu3jkem4cseejktwllb6dgsam7cx3jy63pazejzobvabcd"
-OCI_HOME_REGION="us-sanjose-1"
-OCI_TENANT_NAME="main tenant"
-LACEWORK_PRIVATE_KEY_PATH="/pathto/oci_api_key_lacework.pem"
-LACEWORK_PRIVATE_KEY_FINGERPRINT="1c:17:64:82:0d:86:c8:1d:8a:b6:d1:12:b7:a4:b2:cc"
+LACEWORK_OCI_USERNAME="<user_ocid>"
+OCI_TENANCY_OCID="<tenancy_ocid>"
+OCI_HOME_REGION="<home_region>"
+OCI_TENANT_NAME="<tenant_name>"
+LACEWORK_PRIVATE_KEY_PATH="<private_key_path>"
+LACEWORK_PRIVATE_KEY_FINGERPRINT="<fingerprint>"
 
 LACEWORK_INTEGRATION_NAME="oci-$OCI_TENANT_NAME"
 contents=$(cat $LACEWORK_PRIVATE_KEY_PATH)

--- a/lw-oci-integration/bash/lacework_integration_payload.sh
+++ b/lw-oci-integration/bash/lacework_integration_payload.sh
@@ -7,11 +7,12 @@ fi
 
 OUTPUT_FILE="lacework_payload.json"
 
+# Values of 6 variables below should be changed before running script:
+
 LACEWORK_OCI_USERNAME="ocid1.user.oc1..aaaaaaaaa3sq6j7icod2o6iky5smahcgt6xurxkuxzigyumpcg4rgyq5abcd"
 OCI_TENANCY_OCID="ocid1.tenancy.oc1..aaaaaaaatxph3zpu3jkem4cseejktwllb6dgsam7cx3jy63pazejzobvabcd"
 OCI_HOME_REGION="us-sanjose-1"
 OCI_TENANT_NAME="main tenant"
-
 LACEWORK_PRIVATE_KEY_PATH="/pathto/oci_api_key_lacework.pem"
 LACEWORK_PRIVATE_KEY_FINGERPRINT="1c:17:64:82:0d:86:c8:1d:8a:b6:d1:12:b7:a4:b2:cc"
 


### PR DESCRIPTION
Also adding README.md
For manual flow, particularly for IDCS tenancies, the separate script is required to help with formatting payload.