### PR TITLE
Script to generate a resource count report

### DIFF
--- a/lw-oci-integration/usage_metrics/README.md
+++ b/lw-oci-integration/usage_metrics/README.md
@@ -1,0 +1,31 @@
+# OCI Usage Metrics
+This directory contains a simple python script that can be executed in the OCI Cloud Shell to capture information about active counts per resource type.
+
+## Policy requirements
+The script uses the search API to query resources in a tenancy. The user profile (`DEFAULT` profile in oci config) that runs the script needs the correct set of policies to run it successfully. These policies are the
+same, or weaker than those needed to *collect* the resource information in a Lacework integration, which is presented in [the terraform script](https://github.com/lacework/terraform-oci-config/blob/main/main.tf).
+
+## Running the script
+
+1. Login to the Console in the tenancy and region with most data volume.
+2. Click the Cloud Shell icon in the Console header. Note that Cloud Shell will execute commands against the region selected in the Console's Region selection menu when Cloud Shell was started.
+3. Run Python:
+    ```
+    user@cloudshell:oci (us-phoenix-1)$ python3
+    Python 3.6.8 (default, Oct  1 2020, 20:32:44) 
+    [GCC 4.8.5 20150623 (Red Hat 4.8.5-44.0.3)] on linux
+    Type "help", "copyright", "credits" or "license" for more information.
+    >>> 
+    ```
+### Generate CSV with data count information
+To run the code, you can either
+1. copy the contents of `oci_usage_metrics.py` in the console or 
+2. use the upload file (https://docs.oracle.com/en-us/iaas/Content/API/Concepts/devcloudshellgettingstarted.htm#ariaid-title3) and run `python oci_usage_metrics.py`
+
+## Downloading the File
+To download a file from Cloud Shell:
+
+1. Click the Cloud Shell menu at the top left of the Cloud Shell window and select Download. The File Download dialog appears:
+2. Type in the name of the file in your home directory that you want to download, should be `OCIUsageMetrics.csv`.
+3. Click the Download button.
+4. The File Transfer dialog will indicate the status of the download.

--- a/lw-oci-integration/usage_metrics/README.md
+++ b/lw-oci-integration/usage_metrics/README.md
@@ -19,8 +19,8 @@ same, or weaker than those needed to *collect* the resource information in a Lac
     ```
 ### Generate CSV with data count information
 To run the code, you can either
-1. copy the contents of `oci_usage_metrics.py` in the console or 
-2. use the upload file (https://docs.oracle.com/en-us/iaas/Content/API/Concepts/devcloudshellgettingstarted.htm#ariaid-title3) and run `python oci_usage_metrics.py`
+1. Copy the contents of `oci_usage_metrics.py` in the console (or) 
+2. Use the upload the `oci_usage_metrics.py` file feature described [here](https://docs.oracle.com/en-us/iaas/Content/API/Concepts/devcloudshellgettingstarted.htm#ariaid-title3) and run `python oci_usage_metrics.py`
 
 ## Downloading the File
 To download a file from Cloud Shell:

--- a/lw-oci-integration/usage_metrics/oci_usage_metrics.py
+++ b/lw-oci-integration/usage_metrics/oci_usage_metrics.py
@@ -1,0 +1,23 @@
+import oci
+import csv
+counter = dict()
+QUERY_STRING = "QUERY all resources where lifeCycleState != 'TERMINATED' && lifeCycleState != 'FAILED'"
+search_client = oci.resource_search.ResourceSearchClient(oci.config.from_file())
+structured_search = oci.resource_search.models.StructuredSearchDetails(query=QUERY_STRING)
+next_page = None
+while True:
+    instances = search_client.search_resources(structured_search, page=next_page)
+    for instance in instances.data.items:
+        resource_type = instance.resource_type.lower()
+        if resource_type not in counter:
+            counter[resource_type] = 0
+        counter[resource_type] += 1
+    if not instances.next_page:
+        break
+    next_page = instances.next_page
+
+with open('OCIUsageMetrics.csv', 'w') as csvfile:
+    writer = csv.writer(csvfile)
+    writer.writerow(['Resource', 'Count'])
+    for row in counter.items():
+        writer.writerow(row)


### PR DESCRIPTION
This PR adds a simple script to query all the resources under an OCI tenancy. It's used to estimate the usage numbers for performance testing.

A readme is provided on how to run the script.