### PR TITLE
Added check for jq to lw_aws_inventory script

### DIFF
--- a/bash/lw_aws_inventory.sh
+++ b/bash/lw_aws_inventory.sh
@@ -153,6 +153,15 @@ then
   exit
 fi
 
+#Ensure jq is installed
+
+if ! command -v jq &> /dev/null
+then
+    echo "The script requires jq to run."
+    echo "See https://jqlang.github.io/jq/download/ for installation options."
+    exit 1
+fi
+
 # Set the initial counts to zero.
 ACCOUNTS=0
 ORGANIZATIONS=0


### PR DESCRIPTION
I've had multiple prospects run our inventory scripts unsuccessfully, often times due to them not having `jq` on their host. This PR just checks for the command and exits gracefully if it is not found, providing an error message.